### PR TITLE
修复价格提取和多语言套餐名称识别问题

### DIFF
--- a/spotify_rate_converter.py
+++ b/spotify_rate_converter.py
@@ -175,6 +175,16 @@ def standardize_plan_name(plan_name):
         'premium 個人': 'Premium Individual',
         'premium个人': 'Premium Individual',
         'premium 个人': 'Premium Individual',
+        # 法语
+        'premium personnel': 'Premium Individual',
+        # 芬兰语
+        'yksilö-premium': 'Premium Individual',
+        # 匈牙利语
+        'egyéni premium csomag': 'Premium Individual',
+        # 韩语/日语
+        'premium standard': 'Premium Individual',
+        # 斯瓦希里语
+        'premium ya binafsi': 'Premium Individual',
         
         # Student plans
         'premium para estudiantes': 'Premium Student',
@@ -189,6 +199,14 @@ def standardize_plan_name(plan_name):
         'premium 大学生': 'Premium Student',
         'premium 學生': 'Premium Student',
         'premium學生': 'Premium Student',
+        # 法语
+        'premium étudiants': 'Premium Student',
+        # 芬兰语
+        'opiskelija‑premium': 'Premium Student',
+        # 匈牙利语
+        'hallgatói premium csomag': 'Premium Student',
+        # 摩洛哥法语
+        'premium étudiants': 'Premium Student',
         
         # Duo plans
         'premium duo': 'Premium Duo',
@@ -198,6 +216,10 @@ def standardize_plan_name(plan_name):
         'premium 雙人': 'Premium Duo',
         'premium双人': 'Premium Duo',
         'premium 双人': 'Premium Duo',
+        # 芬兰语
+        'duo‑premium': 'Premium Duo',
+        # 匈牙利语
+        'premium duo csomag': 'Premium Duo',
         
         # Family plans
         'premium familiar': 'Premium Family',
@@ -209,6 +231,16 @@ def standardize_plan_name(plan_name):
         'premium 家庭': 'Premium Family',
         'premium家族': 'Premium Family',
         'premium 家族': 'Premium Family',
+        # 芬兰语
+        'perhe‑premium': 'Premium Family',
+        # 匈牙利语
+        'családi premium csomag': 'Premium Family',
+        # 斯瓦希里语
+        'premium ya familia': 'Premium Family',
+        
+        # Special/Other plans
+        'premium basic': 'Premium Basic',  # 韩国特殊套餐
+        'premium lite': 'Premium Lite',    # 哥伦比亚等
         
         # Free plans
         'spotify free': 'Spotify Free',
@@ -224,24 +256,31 @@ def standardize_plan_name(plan_name):
         return standardization_map[plan_lower]
     
     # 模糊匹配（包含关键词）
-    if 'individual' in plan_lower or 'personal' in plan_lower:
+    if any(keyword in plan_lower for keyword in ['individual', 'personal', 'personnel', 'yksilö', 'egyéni', 'binafsi']):
         if 'premium' in plan_lower:
             return 'Premium Individual'
     
-    if any(keyword in plan_lower for keyword in ['estudiante', 'student', 'étudiant', 'studenten', '学生', '學生', '大学生']):
+    if any(keyword in plan_lower for keyword in ['estudiante', 'student', 'étudiant', 'studenten', 'opiskelija', 'hallgatói', '学生', '學生', '大学生']):
         if 'premium' in plan_lower:
             return 'Premium Student'
     
-    if 'duo' in plan_lower or 'couple' in plan_lower or '双人' in plan_lower or '雙人' in plan_lower:
+    if any(keyword in plan_lower for keyword in ['duo', 'couple', '双人', '雙人']):
         if 'premium' in plan_lower:
             return 'Premium Duo'
     
-    if any(keyword in plan_lower for keyword in ['familiar', 'family', 'família', 'famille', 'familie', '家庭', '家族']):
+    if any(keyword in plan_lower for keyword in ['familiar', 'family', 'família', 'famille', 'familie', 'perhe', 'családi', 'familia', '家庭', '家族']):
         if 'premium' in plan_lower:
             return 'Premium Family'
     
     if any(keyword in plan_lower for keyword in ['free', 'gratuito', 'gratuit', '免費', '免费']):
         return 'Spotify Free'
+    
+    # 特殊处理
+    if 'basic' in plan_lower and 'premium' in plan_lower:
+        return 'Premium Basic'
+    
+    if 'lite' in plan_lower and 'premium' in plan_lower:
+        return 'Premium Lite'
     
     # 如果没有匹配到，保持原名称但首字母大写
     return plan_name.title()

--- a/spotify_rate_converter.py
+++ b/spotify_rate_converter.py
@@ -466,9 +466,11 @@ def sort_by_family_plan_cny(processed_data, original_data):
     for country_code, country_info in processed_data.items():
         family_plan = None
         
-        # Find Premium Family plan
+        # Find Premium Family plan (支持多语言)
         for plan in country_info.get('plans', []):
-            if 'Premium Family' in plan.get('plan', ''):
+            plan_name = plan.get('plan', '')
+            if ('Premium Family' in plan_name or 'Premium Familiar' in plan_name or 
+                'Premium Famille' in plan_name or 'Premium Familie' in plan_name):
                 family_plan = plan
                 break
         
@@ -490,7 +492,10 @@ def sort_by_family_plan_cny(processed_data, original_data):
         # 获取原始 price_number 数值进行格式化
         original_price_number = None
         for original_plan in original_data.get(country_code, {}).get('plans', []):
-            if 'Premium Family' in original_plan.get('plan', ''):
+            plan_name = original_plan.get('plan', '')
+            # 支持多语言的家庭套餐名称
+            if ('Premium Family' in plan_name or 'Premium Familiar' in plan_name or 
+                'Premium Famille' in plan_name or 'Premium Familie' in plan_name):
                 original_price_number = original_plan.get('price_number')
                 break
         
@@ -602,7 +607,10 @@ def main():
                 if country_code.startswith('_'):
                     continue
                 for plan in country_info.get('plans', []):
-                    if 'Premium Family' in plan.get('plan', '') and plan.get('price_cny') is not None:
+                    plan_name = plan.get('plan', '')
+                    if (('Premium Family' in plan_name or 'Premium Familiar' in plan_name or 
+                         'Premium Famille' in plan_name or 'Premium Familie' in plan_name) and 
+                        plan.get('price_cny') is not None):
                         country_name_cn = COUNTRY_NAMES_CN.get(country_code, country_info['country_name'])
                         print(f"{count+1:2d}. {country_name_cn:15s} ({country_code}): "
                               f"¥{plan['price_cny']:7.2f} ({plan['currency']} {plan.get('price_number', 'N/A')})")


### PR DESCRIPTION
  修复内容

  1. 修复美元符号正则表达式匹配问题
    - 将货币模式中的 \$ 改为 [$] 字符集形式
    - 解决阿根廷、玻利维亚等国家价格数字识别错误的问题
    - 现在能正确处理千位分隔符(2.499→2499)和欧洲小数点格式(5,99→5.99)
  2. 添加多语言家庭套餐名称支持
    - 支持 Premium Family(英语)、Premium Familiar(西班牙语)、Premium Famille(法语)、Premium Familie(德语)
    - 修复阿根廷等西语国家 price_number 为 null 的问题
    - 影响文件：spotify_rate_converter.py 三处搜索逻辑
  3. 优化货币检测逻辑
    - 优先使用国家货币映射表 SPOTIFY_REAL_CURRENCY_MAP
    - 提高货币识别准确性

  修复效果

  - ✅ 阿根廷：$ 2.499 → ARS 2,499 (之前显示为 ARS 2.499)
  - ✅ 玻利维亚：USD 5,99 → USD 5.99 (之前显示为 USD 599)
  - ✅ 阿根廷家庭版：显示 ARS 4,199 (之前为 null)